### PR TITLE
Revert "Bump actions/download-artifact from 2 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v2
         with:
           name: production-files
           path: ./dist


### PR DESCRIPTION
Reverts Axtazer/Axta-Web#6